### PR TITLE
added a platforms folder for site specific config

### DIFF
--- a/platforms/ucl_cs_cluster/include
+++ b/platforms/ucl_cs_cluster/include
@@ -1,0 +1,23 @@
+#this file is common to install and source
+
+#path to create the venv
+export CATH_VENV_PATH=~/cath_venv
+
+#path to install gcloud
+export CATH_GCLOUD=~/gcloud
+export CATH_GCLOUD_USER='robert.vickerstaff.aws@gmail.com'
+
+#path to clone the repo to
+export REPOS_PATH=~/repos
+export REPO_NAME=cath-alphaflow
+export CATH_REPO_PATH=${REPOS_PATH}/${REPO_NAME}
+
+#path to store bulk data outside the repo path if required
+#eg if repo is on home and bulk storage is a project folder somewhere else?
+export CATH_DATA_PATH=~/cath-workspace-test
+
+#put python, java and google cloud sdk in the path
+source /share/apps/source_files/python/python-3.9.5.source
+export PATH=/share/apps/java/bin:${PATH}
+export PATH=${CATH_GCLOUD}/google-cloud-sdk/bin:${PATH}
+

--- a/platforms/ucl_cs_cluster/install
+++ b/platforms/ucl_cs_cluster/install
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+#initial install of everything using pip, wget and git clone
+#also currently runs cath-af pytest and nextflow hello example
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/include
+
+#venv setup, install dependencies
+python3 -m venv ${CATH_VENV_PATH}
+. ${CATH_VENV_PATH}/bin/activate
+pip install --upgrade pip wheel pytest nextflow
+
+#get gcloud utils
+mkdir -p ${CATH_GCLOUD}
+cd ${CATH_GCLOUD}
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-415.0.0-linux-x86_64.tar.gz
+tar -xf google-cloud-cli-415.0.0-linux-x86_64.tar.gz
+
+#get cath-af repo
+mkdir -p ${REPOS_PATH}
+cd ${REPOS_PATH}
+git clone https://github.com/UCLOrengoGroup/cath-alphaflow.git
+cd ${REPO_NAME}
+pip install -e .
+pytest
+
+#test nextflow
+cd ~
+nextflow run hello
+
+##move into data processing folder
+#mkdir -p ${CATH_DATA_PATH}
+#cd ${CATH_DATA_PATH}
+#nextflow run ${CATH_REPO_PATH}/workflows/cath-test-workflow.nf

--- a/platforms/ucl_cs_cluster/source
+++ b/platforms/ucl_cs_cluster/source
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#script to setup environment ready to use each time
+#only tested interactively in a qrsh session so far
+#uasge example: [rvickers@pchuckle cath-alphaflow]$ source ./platforms/ucl_cs_cluster/source
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/include
+. ${CATH_VENV_PATH}/bin/activate
+
+#login to gcloud, generates interactive prompt
+gcloud auth login ${CATH_GLOUD_USER}


### PR DESCRIPTION
created this as a place to record all the CS cluster specific config I am doing using rough bash scripts, final form may change. I've not change any workflows. I have locally disabled the nextflow script thing which hides any gsutil errors as I needed those for debugging, but have not pushed that change. Ideally we need something that only hides innocuous errors and lets stuff like "gsutil command not found" through.