### PR TITLE
fix: correct LUR calculation for discontinuous domains

### DIFF
--- a/cath_alphaflow/commands/extract_plddt_and_lur.py
+++ b/cath_alphaflow/commands/extract_plddt_and_lur.py
@@ -157,7 +157,7 @@ def get_LUR_residues_percentage(cif_path: Path, *, chopping=None, acc_id=None):
     LUR_res = 0
     LUR_stretch = False
     min_res_lur = MIN_LENGTH_LUR
-    for residue in segment_plddt:
+    for residue in chopping_plddt:
         plddt_res = float(residue)
         if plddt_res < 70:
             LUR_res += 1


### PR DESCRIPTION
Fixes a typo that miscalculated LUR in discontinuous domains: it was only considering the final segment rather than the full chopping
